### PR TITLE
Lookup `Performance` in the system dictionary

### DIFF
--- a/Phausto/DSP.class.st
+++ b/Phausto/DSP.class.st
@@ -188,11 +188,14 @@ DSP class >> initializedDSP: anObject [
 	initializedDSP := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'exceptions' }
 DSP class >> invalidException [
 
-Performance uniqueInstance stop.
-^ Error new signal: ('This DSP is not valid - check its creation'  , PhaustoDynamicEngine uniqueInstance getLastError )
+	Smalltalk
+		at: #Performance
+		ifPresent: [ :performance | performance uniqueInstance stop ].
+	^ Error new signal: 'This DSP is not valid - check its creation'
+		  , PhaustoDynamicEngine uniqueInstance getLastError
 ]
 
 { #category : 'as yet unclassified' }


### PR DESCRIPTION
Fixes #35.
This avoids the dependency on the `Performance` class.
Doing a lookup in the system dictionary can be questionable, but the error caused by using an absent class can end up in an infinite loop on image startup, essentially killing the image, so it should be worth it.