### PR TITLE
Feature/late as box transformation

### DIFF
--- a/Phausto/ASinh1.class.st
+++ b/Phausto/ASinh1.class.st
@@ -21,7 +21,7 @@ ASinh1 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/ASinh2.class.st
+++ b/Phausto/ASinh2.class.st
@@ -21,7 +21,7 @@ ASinh2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Allpass_Comb.class.st
+++ b/Phausto/Allpass_Comb.class.st
@@ -38,8 +38,8 @@ Allpass_Comb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self intDel ,  self aN
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox , self intDel asBox , self aN asBox
+	            , self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Allpass_FComb.class.st
+++ b/Phausto/Allpass_FComb.class.st
@@ -39,8 +39,8 @@ Allpass_FComb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self del ,  self aN , self input
-		            connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self aN asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Allpass_FComb1a.class.st
+++ b/Phausto/Allpass_FComb1a.class.st
@@ -41,8 +41,8 @@ Allpass_FComb1a >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self del ,  self aN , self input
-		            connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self aN asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Allpass_FComb5.class.st
+++ b/Phausto/Allpass_FComb5.class.st
@@ -40,8 +40,8 @@ Allpass_FComb5 >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self del , self aN , self input
-		            connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self aN asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/ArcTan.class.st
+++ b/Phausto/ArcTan.class.st
@@ -21,7 +21,7 @@ ArcTan >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/ArcTan2.class.st
+++ b/Phausto/ArcTan2.class.st
@@ -21,7 +21,7 @@ ArcTan2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/AutoWah.class.st
+++ b/Phausto/AutoWah.class.st
@@ -20,7 +20,7 @@ AutoWah >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self level , self input  connectTo: intermediateBox.
+	finalBox := self level asBox , self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/BasicCountersTest.class.st
+++ b/Phausto/BasicCountersTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'BasicsCountersTest',
+	#name : 'BasicCountersTest',
 	#superclass : 'TestCase',
 	#category : 'Phausto-Tests',
 	#package : 'Phausto',
@@ -7,31 +7,31 @@ Class {
 }
 
 { #category : 'tests' }
-BasicsCountersTest >> testCountDownAsDsp [
+BasicCountersTest >> testCountDownAsDsp [
 
 	self assert: PhCountDown new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testCountUpAsDsp [
+BasicCountersTest >> testCountUpAsDsp [
 
 	self assert: PhCountUp new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testCounterAsDsp [
+BasicCountersTest >> testCounterAsDsp [
 
 	self assert: Counter new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhBeatAsDsp [
+BasicCountersTest >> testPhBeatAsDsp [
 
 	self assert: PhBeat new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhCycleAsDsp [
+BasicCountersTest >> testPhCycleAsDsp [
 	"crash apparently for unexplicable reason"
 
 	self assert: 1 equals: 0
@@ -39,43 +39,43 @@ BasicsCountersTest >> testPhCycleAsDsp [
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhLineAsDsp [
+BasicCountersTest >> testPhLineAsDsp [
 
 	self assert: PhLine  new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhPeriodAsDsp [
+BasicCountersTest >> testPhPeriodAsDsp [
 
 	self assert: PhPeriod  new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhRampAsDsp [
+BasicCountersTest >> testPhRampAsDsp [
 
 	self assert: PhRamp new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhTempoAsDsp [
+BasicCountersTest >> testPhTempoAsDsp [
 
 	self assert: PhTempo new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPhTimeAsDsp [
+BasicCountersTest >> testPhTimeAsDsp [
 
 	self assert: PhTime new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulseAsDsp [
+BasicCountersTest >> testPulseAsDsp [
 
 	self assert: Pulse new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulseCountDownAsDsp [
+BasicCountersTest >> testPulseCountDownAsDsp [
 
 "crash apparently for unexplicable reason"
 
@@ -84,13 +84,13 @@ BasicsCountersTest >> testPulseCountDownAsDsp [
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulseCountDownLoopAsDsp [
+BasicCountersTest >> testPulseCountDownLoopAsDsp [
 
 	self assert: PulseCountDownLoop new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulseCountUpAsDsp [
+BasicCountersTest >> testPulseCountUpAsDsp [
 
 "crash apparently for unexplicable reason"
 
@@ -99,25 +99,25 @@ BasicsCountersTest >> testPulseCountUpAsDsp [
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulseCountUpLoopAsDsp [
+BasicCountersTest >> testPulseCountUpLoopAsDsp [
 
 	self assert: PulseCountUpLoop new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testPulsenAsDsp [
+BasicCountersTest >> testPulsenAsDsp [
 
 	self assert: Pulsen new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testResetCtrAsDsp [
+BasicCountersTest >> testResetCtrAsDsp [
 
 	self assert: PhResetCtr new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }
-BasicsCountersTest >> testSpulsedAsDsp [
+BasicCountersTest >> testSpulsedAsDsp [
 
 "crash apparently for unexplicable reason"
 

--- a/Phausto/BasiconvertersTest.class.st
+++ b/Phausto/BasiconvertersTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'BasiconvertersTest',
+	#name : 'BasiConvertersTest',
 	#superclass : 'TestCase',
 	#category : 'Phausto-Tests',
 	#package : 'Phausto',
@@ -7,19 +7,103 @@ Class {
 }
 
 { #category : 'tests' }
-BasiconvertersTest >> testDb2Linear [
+BasiConvertersTest >> testCent2RatioAsDsp [
+
+	self deny: PhCent2Ratio new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testDb2Linear [
 
 	self deny: PhDb2Linear new asDsp isNull
 ]
 
 { #category : 'tests' }
-BasiconvertersTest >> testLinear2dB [ 
+BasiConvertersTest >> testHz2MidiKeyAsDsp [
+
+	self deny: PhHz2MidiKey new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testLinea2LogGainAsDsp [
+
+	self deny: PhLinear2LogGain new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testLinear2dB [ 
 
 	self deny: PhLinear2Db new asDsp isNull
 ]
 
 { #category : 'tests' }
-BasiconvertersTest >> testSamp2Sec [
+BasiConvertersTest >> testLog2LinearGainAsDsp [
+
+	self deny: PhLog2LinearGain new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testPhHz2PianoKeyAsDsp [
+
+	self deny: PhHz2PianoKey new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testPhMidiKey2HzAsDsp [
+
+	self deny: PhMidiKey2Hz new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testPhPole2TaueAsDsp [
+
+	self deny: PhPole2tau new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testPhTau2PoleAsDsp [
+
+	self deny: PhTau2Pole new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testPianoKey2HzAsDsp [
+
+	self deny: PhPianoKey2Hz new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testRatio2CentAsDsp [
+
+
+self deny: 1 == 1.
+	"self deny: PhRatio2Cent new asDsp isNull"
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testRatio2SemitoneAsDsp [
+
+
+self deny: 1 == 1.
+	"self deny: PhRatio2Semitone new asDsp isNull"
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testSamp2Sec [
 
 self deny: PhSamp2Sec new asDsp isNull.
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testSec2Samples [ 
+
+	self deny: PhSec2Samp new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiConvertersTest >> testSemi2RatioAsDsp [
+
+
+self deny: 1 == 1.
+	"self deny: PhSemi2Ratio new asDsp isNull"
 ]

--- a/Phausto/BasiconvertersTest.class.st
+++ b/Phausto/BasiconvertersTest.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : 'BasiconvertersTest',
+	#superclass : 'TestCase',
+	#category : 'Phausto-Tests',
+	#package : 'Phausto',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+BasiconvertersTest >> testDb2Linear [
+
+	self deny: PhDb2Linear new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiconvertersTest >> testLinear2dB [ 
+
+	self deny: PhLinear2Db new asDsp isNull
+]
+
+{ #category : 'tests' }
+BasiconvertersTest >> testSamp2Sec [
+
+self deny: PhSamp2Sec new asDsp isNull.
+]

--- a/Phausto/BasicsCountersTest.class.st
+++ b/Phausto/BasicsCountersTest.class.st
@@ -1,0 +1,127 @@
+Class {
+	#name : 'BasicsCountersTest',
+	#superclass : 'TestCase',
+	#category : 'Phausto-Tests',
+	#package : 'Phausto',
+	#tag : 'Tests'
+}
+
+{ #category : 'tests' }
+BasicsCountersTest >> testCountDownAsDsp [
+
+	self assert: PhCountDown new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testCountUpAsDsp [
+
+	self assert: PhCountUp new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testCounterAsDsp [
+
+	self assert: Counter new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhBeatAsDsp [
+
+	self assert: PhBeat new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhCycleAsDsp [
+	"crash apparently for unexplicable reason"
+
+	self assert: 1 equals: 0
+	"self assert: PhCycle new asDsp isNull equals: false"
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhLineAsDsp [
+
+	self assert: PhLine  new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhPeriodAsDsp [
+
+	self assert: PhPeriod  new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhRampAsDsp [
+
+	self assert: PhRamp new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhTempoAsDsp [
+
+	self assert: PhTempo new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPhTimeAsDsp [
+
+	self assert: PhTime new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulseAsDsp [
+
+	self assert: Pulse new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulseCountDownAsDsp [
+
+"crash apparently for unexplicable reason"
+
+	self assert: 1 equals: 0
+	"self assert: PulseCountDown new asDsp isNull equals: false"
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulseCountDownLoopAsDsp [
+
+	self assert: PulseCountDownLoop new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulseCountUpAsDsp [
+
+"crash apparently for unexplicable reason"
+
+	self assert: 1 equals: 0
+	"self assert: PulseCountUp new asDsp isNull equals: false"
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulseCountUpLoopAsDsp [
+
+	self assert: PulseCountUpLoop new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testPulsenAsDsp [
+
+	self assert: Pulsen new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testResetCtrAsDsp [
+
+	self assert: PhResetCtr new asDsp isNull equals: false
+]
+
+{ #category : 'tests' }
+BasicsCountersTest >> testSpulsedAsDsp [
+
+"crash apparently for unexplicable reason"
+
+	self assert: 1 equals: 0
+
+	"self assert: Sweep new asDsp isNull equals: false"
+]

--- a/Phausto/BasicsTest.class.st
+++ b/Phausto/BasicsTest.class.st
@@ -7,24 +7,6 @@ Class {
 }
 
 { #category : 'tests' }
-BasicsTest >> testCountDownAsDsp [
-
-	self assert: CountDown new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testCountUpAsDsp [
-
-	self assert: CountUp new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testCounterAsDsp [
-
-	self assert: Counter new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
 BasicsTest >> testDownSamplerAsDsp [
 	"crash apparently for unexplicable reason"
 
@@ -45,98 +27,6 @@ BasicsTest >> testPhAutomatAsDsp [
 ]
 
 { #category : 'tests' }
-BasicsTest >> testPhBeatAsDsp [
-
-	self assert: PhBeat new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhCycleAsDsp [
-	"crash apparently for unexplicable reason"
-
-	self assert: 1 equals: 0
-	"self assert: PhCycle new asDsp isNull equals: false"
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhLineAsDsp [
-
-	self assert: PhLine  new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhPeriodAsDsp [
-
-	self assert: PhPeriod  new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhRampAsDsp [
-
-	self assert: PhRamp new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhTempoAsDsp [
-
-	self assert: PhTempo new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPhTimeAsDsp [
-
-	self assert: PhTime new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulseAsDsp [
-
-	self assert: Pulse new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulseCountDownAsDsp [
-
-"crash apparently for unexplicable reason"
-
-	self assert: 1 equals: 0
-	"self assert: PulseCountDown new asDsp isNull equals: false"
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulseCountDownLoopAsDsp [
-
-	self assert: PulseCountDownLoop new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulseCountUpAsDsp [
-
-"crash apparently for unexplicable reason"
-
-	self assert: 1 equals: 0
-	"self assert: PulseCountUp new asDsp isNull equals: false"
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulseCountUpLoopAsDsp [
-
-	self assert: PulseCountUpLoop new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testPulsenAsDsp [
-
-	self assert: Pulsen new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testResetCtrAsDsp [
-
-	self assert: ResetCtr new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
 BasicsTest >> testSampleAndHoldAsDsp [
 
 	self assert: SampleAndHold new asDsp isNull equals: false
@@ -146,14 +36,4 @@ BasicsTest >> testSampleAndHoldAsDsp [
 BasicsTest >> testSelectNAsDsp [
 
 	self assert: PhSelectN new asDsp isNull equals: false
-]
-
-{ #category : 'tests' }
-BasicsTest >> testSpulsedAsDsp [
-
-"crash apparently for unexplicable reason"
-
-	self assert: 1 equals: 0
-
-	"self assert: Sweep new asDsp isNull equals: false"
 ]

--- a/Phausto/Blower.class.st
+++ b/Phausto/Blower.class.st
@@ -26,9 +26,9 @@ Blower >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 	finalBox := self pressure asBox , self breathGain asBox
-	            , self breathCutoff connectTo: intermediateBox.
+	            , self breathCutoff asBox connectTo: intermediateBox.
 
-	^ intermediateBox 
+	^ intermediateBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/ButterworthLPHP.class.st
+++ b/Phausto/ButterworthLPHP.class.st
@@ -21,25 +21,25 @@ ButterworthLPHP >> cutoff [
 ]
 
 { #category : 'initialization' }
-ButterworthLPHP >> initialize [ 
+ButterworthLPHP >> initialize [
 
-super initialize .
-cutoff := PhHSlider new
-				            label: self label , 'Cutoff'
-				            init: 300
-				            min: 20
-				            max: 18000
-				            step: 1
+	super initialize.
+	cutoff := PhHSlider new
+		          label: self label , 'Cutoff'
+		          init: 300
+		          min: 20
+		          max: 18000
+		          step: 1.
+		 poles := PhHSlider new
+				           label: self label , 'Poles'
+				           init: 5000
+				           min: 20
+				           max: 18000
+				           step: 1 
 ]
 
 { #category : 'accessing' }
 ButterworthLPHP >> poles [
 
-	^ poles ifNil:  [
-		  poles  := PhHSlider new
-			          label: self label , 'Poles'
-			          init: 5000
-			          min: 20
-			          max: 18000
-			          step: 1 ] 
+	^ poles 
 ]

--- a/Phausto/ButterworthLPHP.class.st
+++ b/Phausto/ButterworthLPHP.class.st
@@ -17,13 +17,19 @@ Class {
 { #category : 'accessing' }
 ButterworthLPHP >> cutoff [
 
-	^ cutoff ifNil:  [
-		  cutoff  := PhHSlider new
-			          label: self label , 'Cutoff'
-			          init: 300
-			          min: 20
-			          max: 18000
-			          step: 1 ] 
+	^ cutoff
+]
+
+{ #category : 'initialization' }
+ButterworthLPHP >> initialize [ 
+
+super initialize .
+cutoff := PhHSlider new
+				            label: self label , 'Cutoff'
+				            init: 300
+				            min: 20
+				            max: 18000
+				            step: 1
 ]
 
 { #category : 'accessing' }

--- a/Phausto/CasioCZOscillators.class.st
+++ b/Phausto/CasioCZOscillators.class.st
@@ -50,9 +50,12 @@ CasioCZOscillators >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	self hasResParameter ifTrue: [ finalBox := self fund , self res connectTo: intermediateBox ] ifFalse:
-	[finalBox := self fund , self index connectTo: intermediateBox].
-	^ finalBox * self uLevel
+	self hasResParameter
+		ifTrue: [
+		finalBox := self fund asBox, self res asBox connectTo: intermediateBox ]
+		ifFalse: [
+		finalBox := self fund asBox , self index asBox connectTo: intermediateBox ].
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/CombFilters.class.st
+++ b/Phausto/CombFilters.class.st
@@ -45,36 +45,36 @@ CombFilters >> initialize [
 		                     first asLowercase.
 	super initialize.
 	processExpression := 'process = fi.' , faustFunctionName , ';'.
-	
-del := PhHSlider new
-			         label: self label , 'del'
-			         init: 2
-			         min: 0
-			         max: 32
-			         step: 0.01 .
-			
-		bM := PhHSlider new
-			       label: self label , 'BM'
-			       init: 1
-			       min: 0
-			       max: 1
-			       step: 0.001 .
-			 b0 := PhHSlider new
-			       label: self label , 'B0'
-			       init: 1
-			       min: 0
-			       max: 1
-			       step: 0.001.
-			
-		input := 1 asBox.
-		
+
+	del := PhHSlider new
+		       label: self label , 'del'
+		       init: 2
+		       min: 0
+		       max: 32
+		       step: 0.01.
+
+	bM := PhHSlider new
+		      label: self label , 'BM'
+		      init: 1
+		      min: 0
+		      max: 1
+		      step: 0.001.
+	b0 := PhHSlider new
+		      label: self label , 'B0'
+		      init: 1
+		      min: 0
+		      max: 1
+		      step: 0.001.
+
+	input := 1 .
+
 	intDel := PhHSlider new
-			            label: self label , 'IntDel'
-			            init: 2
-			            min: 0
-			            max: 32
-			            step: 1 .
-			maxDel := 32 asBox.
+		          label: self label , 'IntDel'
+		          init: 2
+		          min: 0
+		          max: 32
+		          step: 1.
+	maxDel := 32 asBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/CountDown.class.st
+++ b/Phausto/CountDown.class.st
@@ -8,9 +8,9 @@ Class {
 		'max',
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -19,9 +19,8 @@ CountDown >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	
-	finalBox := self max , self  trig  connectTo:
-		            intermediateBox.
+
+	finalBox := self max asBox , self trig asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
@@ -29,24 +28,24 @@ CountDown >> asBox [
 CountDown >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.countdown;'
+	processExpression := 'process = ba.countdown;'.
+	max := PhHSlider new
+		       label: self label , 'Max'
+		       init: 1
+		       min: 1
+		       max: 64
+		       step: 1.
+		trig := PhButton new label: self label , 'Gate'
 ]
 
 { #category : 'as yet unclassified' }
 CountDown >> max [
 
-	^ max  ifNil: [
-		  max := PhHSlider new
-			            label: self label , 'Max'
-			            init: 1
-			            min: 1
-			            max: 64
-			            step: 11 ]
+	^ max 
 ]
 
 { #category : 'accessing' }
 CountDown >> trig [
 
-	^ trig ifNil: [
-		  trig := PhButton new label: self label , 'Gate' ]
+	^ trig 
 ]

--- a/Phausto/CountUp.class.st
+++ b/Phausto/CountUp.class.st
@@ -8,9 +8,9 @@ Class {
 		'max',
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -19,9 +19,8 @@ CountUp >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	
-	finalBox := self max , self  trig  connectTo:
-		            intermediateBox.
+
+	finalBox := self max asBox  , self trig asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
@@ -30,24 +29,23 @@ CountUp >> initialize [
 
 	super initialize.
 	processExpression := 'process = ba.countup;'.
-
+	max := PhHSlider new
+		       label: self label , 'Max'
+		       init: 1
+		       min: 1
+		       max: 64
+		       step: 1.
+	trig := PhButton new label: self label , 'Gate'
 ]
 
 { #category : 'as yet unclassified' }
 CountUp >> max [
 
-	^ max  ifNil: [
-		  max := PhHSlider new
-			            label: self label , 'Max'
-			            init: 1
-			            min: 1
-			            max: 64
-			            step: 11 ]
+	^ max 
 ]
 
 { #category : 'accessing' }
 CountUp >> trig [
 
-	^ trig ifNil: [
-		  trig := PhButton new label: self label , 'Gate' ]
+	^ trig 
 ]

--- a/Phausto/Counter.class.st
+++ b/Phausto/Counter.class.st
@@ -10,9 +10,9 @@ Class {
 	#instVars : [
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -22,7 +22,7 @@ Counter >> asBox [
 	intermediateBox := super asBox.
 
 
-	finalBox := self trig connectTo: intermediateBox.
+	finalBox := self trig asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
@@ -30,11 +30,12 @@ Counter >> asBox [
 Counter >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.counter;'
+	processExpression := 'process = ba.counter;'.
+	trig := PhButton new label: self label , 'Gate' .
 ]
 
 { #category : 'as yet unclassified' }
 Counter >> trig [
 
-	^ trig ifNil: [ trig := PhButton new label: self label , 'Gate' ]
+	^ trig 
 ]

--- a/Phausto/CryBaby.class.st
+++ b/Phausto/CryBaby.class.st
@@ -26,7 +26,7 @@ CryBaby >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self wah , self input  connectTo: intermediateBox.
+	finalBox := self wah asBox, self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Cubic1.class.st
+++ b/Phausto/Cubic1.class.st
@@ -21,7 +21,7 @@ Cubic1 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/CubicNl.class.st
+++ b/Phausto/CubicNl.class.st
@@ -45,21 +45,21 @@ CubicNl >> initialize [
 
 	super initialize.
 	processExpression := 'process = ef.cubicnl;'.
-	  drive := PhHSlider new
-			         label: self class name , 'Drive'
-			         init: 0.03
-			         min: 0
-			         max: 1
-			         step: 0.001 .
-			
-		offset := PhHSlider new
-			           label: self class name , 'Offset'
-			           init: 0.81
-			           min: 0
-			           max: 1
-			           step: 0.001 .
-			
-		input := 0 asBox 
+	drive := PhHSlider new
+		         label: self class name , 'Drive'
+		         init: 0.03
+		         min: 0
+		         max: 1
+		         step: 0.001.
+
+	offset := PhHSlider new
+		          label: self class name , 'Offset'
+		          init: 0.81
+		          min: 0
+		          max: 1
+		          step: 0.001.
+
+	input := 0 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/CubicNl.class.st
+++ b/Phausto/CubicNl.class.st
@@ -29,7 +29,8 @@ CubicNl >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self drive , self offset, self input  connectTo: intermediateBox.
+	finalBox := self drive asBox , self offset asBox, self input asBox connectTo:
+		            intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/DSP.class.st
+++ b/Phausto/DSP.class.st
@@ -23,7 +23,8 @@ Class {
 		'generatedCode',
 		'displayedUI',
 		'parameters',
-		'isMIDI'
+		'isMIDI',
+		'source'
 	],
 	#classVars : [
 		'defaultName',
@@ -149,7 +150,7 @@ DSP class >> create: aStringWithFaustCode [
 	| currentDsp |
 	currentDsp := PhaustoDynamicEngine uniqueInstance createDsp:
 		              aStringWithFaustCode.
-		1halt.
+	
 	currentDsp isNull ifTrue: [
 		self error: PhaustoDynamicEngine uniqueInstance getLastError ].
 	currentDsp name: 'MyApp'.
@@ -748,6 +749,15 @@ DSP >> soundfiles [
 | allItems |
 allItems := (((STONJSON fromString: self getJSON) at: #ui) at: 1) at: #items.
 ^  allItems select: [ :i | i values includes: 'soundfile' ].
+]
+
+{ #category : 'accessing' }
+DSP >> source [
+	^ source.
+]
+
+{ #category : 'accessing' }
+DSP >> source: aUnitGenerator [
 ]
 
 { #category : 'start-stop' }

--- a/Phausto/DSPTest.class.st
+++ b/Phausto/DSPTest.class.st
@@ -27,3 +27,16 @@ dsp := SquareOsc new asDsp.
 self assertCollection: dsp getUIItemsLabeledDictionary keys  equals: #('SquareOscuLevel' 'SquareOscFreq')
 
 ]
+
+{ #category : 'tests' }
+DSPTest >> testSource [
+
+| osc filter inst dsp |
+osc := SineOsc new.
+filter := ResonBp new.
+inst := filter input: osc .
+dsp :=( osc => filter ) asDsp.
+
+self assert: dsp source class equals: ResonBp 
+
+]

--- a/Phausto/DcBlocker.class.st
+++ b/Phausto/DcBlocker.class.st
@@ -15,7 +15,7 @@ DcBlocker >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox :=  self input connectTo: intermdiateBox.
+	finalBox := self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/DcBlockerAt.class.st
+++ b/Phausto/DcBlockerAt.class.st
@@ -23,7 +23,7 @@ DcBlockerAt >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self fb , self input connectTo: intermdiateBox.
+	finalBox := self fb asBox, self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/DiodeLadder.class.st
+++ b/Phausto/DiodeLadder.class.st
@@ -25,7 +25,8 @@ DiodeLadder >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox, self q asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Djembe.class.st
+++ b/Phausto/Djembe.class.st
@@ -17,8 +17,8 @@ Djembe >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	finalBox := self freq , self strikePosition , self strikeSharpness , self gain , self trigger
-		            connectTo: intermediateBox.
+	finalBox := self freq asBox , self strikePosition asBox , self strikeSharpness asBox 
+	            , self gain asBox , self trigger asBox  connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/DryWetMonoMixer.class.st
+++ b/Phausto/DryWetMonoMixer.class.st
@@ -28,9 +28,9 @@ Class {
 DryWetMonoMixer >> asBox [
 
 	| drySignal wetSignal |
-	drySignal := self input * (1 asBox - self wetAmount).
-	wetSignal := (self input => self fx)  * self wetAmount .
-	^ wetSignal + drySignal 
+	drySignal := self input asBox * (1 asBox - self wetAmount asBox).
+	wetSignal := self input asBox => self fx * self wetAmount asBox.
+	^ wetSignal + drySignal
 ]
 
 { #category : 'accessing' }

--- a/Phausto/EffectsTest.class.st
+++ b/Phausto/EffectsTest.class.st
@@ -95,7 +95,7 @@ EffectsTest >> testGreyHoleDemoAsDsp [
 ]
 
 { #category : 'tests' }
-EffectsTest >> testLimiterMonoAsDsp [
+EffectsTest >> testLimiterMonoAsDsp [ 
 
 	self assert: LimiterMono new asDsp isNull equals: false
 ]

--- a/Phausto/ElecGuitar.class.st
+++ b/Phausto/ElecGuitar.class.st
@@ -21,8 +21,8 @@ ElecGuitar >> asBox [
 	| intermediateBox finalBox length |
 	intermediateBox := super asBox.
 	length := self freq f2l.
-	finalBox := length , self pluckPosition , self mute asBox , self gain , self trigger
-		            connectTo: intermediateBox.
+	finalBox := length , self pluckPosition asBox , self mute asBox , self gain asBox
+	            , self trigger asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]
@@ -44,6 +44,12 @@ ElecGuitar >> initialize [
 
 	super initialize.
 	processExpression := 'process = pm.elecGuitar;'.
+	pluckPosition := (PhHSlider new
+					   label: self label , 'PluckPos'
+					   init: 0.8
+					   min: 0
+					   max: 1
+					   step: 0.01).
 	mute := 1 asBox.
 	trigger := PhButton new label: self label , 'Trigger'.
 	self controlParameters add: #trigger -> (self trigger
@@ -59,13 +65,7 @@ ElecGuitar >> mute [
 { #category : 'accessing' }
 ElecGuitar >> pluckPosition [
 
-	^ pluckPosition ifNil: [
-		  self pluckPosition: (PhHSlider new
-				   label: self label , 'PluckPos'
-				   init: 0.8
-				   min: 0
-				   max: 1
-				   step: 0.01) ]
+	^ pluckPosition 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/EnglishBell.class.st
+++ b/Phausto/EnglishBell.class.st
@@ -21,8 +21,9 @@ EnglishBell >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	finalBox := self strikePosition , self strikeCutoff , self strikeSharpness , self gain
-	            , self trigger connectTo: intermediateBox.
+	finalBox := self strikePosition asBox , self strikeCutoff asBox 
+	            , self strikeSharpness asBox , self gain asBox , self trigger asBox 
+		            connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/F2l.class.st
+++ b/Phausto/F2l.class.st
@@ -20,7 +20,7 @@ F2l >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	finalBox := self freq  connectTo: intermediateBox.
+	finalBox := self freq asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]
@@ -28,13 +28,7 @@ F2l >> asBox [
 { #category : 'accessing' }
 F2l >> freq [
 
-	^ freq ifNil: [
-		  freq := PhHSlider new
-			          label: self label , 'Freq'
-			          init: 440
-			          min: 20
-			          max: 1200
-			          step: 1 ]
+	^ freq 
 ]
 
 { #category : 'accessing' }
@@ -51,5 +45,11 @@ F2l >> freq: aNumberOrABoxOrASymbol [
 F2l >> initialize [
 
 	super initialize.
-	processExpression := 'process = pm.f2l;'
+	processExpression := 'process = pm.f2l;'.
+	freq := PhHSlider new
+		        label: self label , 'Freq'
+		        init: 440
+		        min: 20
+		        max: 1200
+		        step: 1
 ]

--- a/Phausto/FbCombFilter.class.st
+++ b/Phausto/FbCombFilter.class.st
@@ -25,8 +25,8 @@ FbCombFilter >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self intDel , self g
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self intDel asBox, self g asBox, self input asBox
+		            connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Fb_Comb.class.st
+++ b/Phausto/Fb_Comb.class.st
@@ -38,8 +38,8 @@ Fb_Comb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self intDel ,  self b0 , self aN
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self intDel asBox, self b0 asBox, self aN asBox
+	            , self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Fb_FComb.class.st
+++ b/Phausto/Fb_FComb.class.st
@@ -38,8 +38,8 @@ Fb_FComb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel ,  self del , self b0 , self aN
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self b0 asBox, self aN asBox, self input asBox
+		            connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/FfCombFilter.class.st
+++ b/Phausto/FfCombFilter.class.st
@@ -24,8 +24,8 @@ FfCombFilter >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self intDel , self bM
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self intDel asBox, self bM asBox, self input asBox
+		            connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Ff_Comb.class.st
+++ b/Phausto/Ff_Comb.class.st
@@ -23,8 +23,8 @@ Ff_Comb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self intDel , self b0 , self bM
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self intDel asBox, self b0 asBox, self bM asBox
+	            , self input  asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Ff_FComb.class.st
+++ b/Phausto/Ff_FComb.class.st
@@ -22,8 +22,8 @@ Ff_FComb >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel ,  self del , self b0 , self bM
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self b0 asBox, self bM asBox, self input asBox
+		            connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/FfbCombFilter.class.st
+++ b/Phausto/FfbCombFilter.class.st
@@ -25,8 +25,8 @@ FfbCombFilter >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self maxDel , self del, self g
-	            , self input connectTo: intermdiateBox.
+	finalBox := self maxDel asBox, self del asBox, self g asBox, self input  asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/FlangerMono.class.st
+++ b/Phausto/FlangerMono.class.st
@@ -31,8 +31,8 @@ FlangerMono >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := (self dmax, self curdel, self depth, self fb, self invert, self input)
-		            connectTo: intermediateBox.
+	finalBox := self dmax asBox, self curdel asBox, self depth asBox, self fb asBox
+	            , self invert asBox, self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/FractionalDelay.class.st
+++ b/Phausto/FractionalDelay.class.st
@@ -14,7 +14,7 @@ FractionalDelay >> asBox [
 
 	| intermediateBox finalBox delayInSamples |
 	intermediateBox := super asBox.
-	delayInSamples := self delayLength * PhSampleRate new.
+	delayInSamples := self delayLength asBox * PhSampleRate new.
 	finalBox := self maxDelayLength asBox , delayInSamples asBox
 	            , self input asBox connectTo: intermediateBox.
 	^ finalBox

--- a/Phausto/FreeverbMono.class.st
+++ b/Phausto/FreeverbMono.class.st
@@ -63,18 +63,14 @@ FreeverbMono >> initialize [
 		       min: 0
 		       max: 1
 		       step: 0.001.
-		self controlParameters add: #fb1 -> (self fb1
-			 asControlParameterOfWidgetType: #knob
-			 description: 'FeedBack 1').
+	
 	fb2 := PhHSlider new
 		       label: self label , 'Fb2'
 		       init: 0.3
 		       min: 0
 		       max: 1
 		       step: 0.001.
-		self controlParameters add: #fb2 -> (self fb2
-			 asControlParameterOfWidgetType: #knob
-			 description: 'FeedBack 2').
+
 	damp := PhHSlider new
 		        label: self label , 'Damp'
 		        init: 0.2

--- a/Phausto/FreeverbMono.class.st
+++ b/Phausto/FreeverbMono.class.st
@@ -25,10 +25,10 @@ Class {
 { #category : 'converting' }
 FreeverbMono >> asBox [
 
-	| intermediateBox  finalBox |
-		intermediateBox := super asBox.
+	| intermediateBox finalBox |
+	intermediateBox := super asBox.
 	finalBox := self fb1 asBox , self fb2 asBox , self damp asBox
-	            , self spread asBox , self input connectTo:
+	            , self spread asBox , self input asBox connectTo:
 		            intermediateBox.
 
 	^ finalBox

--- a/Phausto/FreeverbMono.class.st
+++ b/Phausto/FreeverbMono.class.st
@@ -63,7 +63,7 @@ FreeverbMono >> initialize [
 		       min: 0
 		       max: 1
 		       step: 0.001.
-	
+
 	fb2 := PhHSlider new
 		       label: self label , 'Fb2'
 		       init: 0.3
@@ -77,7 +77,7 @@ FreeverbMono >> initialize [
 		        min: 0
 		        max: 1
 		        step: 0.001.
-	spread := 0 asBox
+	spread := 0 
 ]
 
 { #category : 'connecting' }

--- a/Phausto/FrenchBell.class.st
+++ b/Phausto/FrenchBell.class.st
@@ -20,10 +20,9 @@ FrenchBell >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-
-	finalBox := self strikePosition , self strikeCutoff , self strikeSharpness , self gain
-	            , self trigger connectTo: intermediateBox.
-
+	finalBox := self strikePosition asBox , self strikeCutoff asBox
+	            , self strikeSharpness asBox , self gain asBox
+	            , self trigger asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/GermanBell.class.st
+++ b/Phausto/GermanBell.class.st
@@ -20,9 +20,9 @@ GermanBell >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-
-	finalBox := self strikePosition , self strikeCutoff , self strikeSharpness , self gain
-	            , self trigger connectTo: intermediateBox.
+	finalBox := self strikePosition asBox , self strikeCutoff asBox
+	            , self strikeSharpness asBox , self gain asBox
+	            , self trigger asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/GreyHole.class.st
+++ b/Phausto/GreyHole.class.st
@@ -39,13 +39,12 @@ Class {
 { #category : 'converting' }
 GreyHole >> asBox [
 
-	| intermediateBox  finalBox |
-	
-	intermediateBox := super asBox .
+	| intermediateBox finalBox |
+	intermediateBox := super asBox.
 	finalBox := self dt asBox , self damp asBox , self size asBox
 	            , self earlyDiff asBox , self feedback asBox
-	            , self modDepth asBox , self modFreq asBox , self inputL
-	            , self inputR connectTo: intermediateBox.
+	            , self modDepth asBox , self modFreq asBox , self inputL asBox
+	            , self inputR asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/GreyHole.class.st
+++ b/Phausto/GreyHole.class.st
@@ -112,16 +112,16 @@ GreyHole >> initialize [
 
 	super initialize.
 	processExpression := 'process = re.greyhole;'.
-	
-	
-	
-	
-	
-	
-	
 
-	self inputL: Wire new asBox.
-	self inputR: Wire new asBox
+
+
+
+
+
+
+
+	self inputL: Wire new .
+	self inputR: Wire new .
 ]
 
 { #category : 'accessing' }

--- a/Phausto/GreyHoleDW.class.st
+++ b/Phausto/GreyHoleDW.class.st
@@ -22,7 +22,7 @@ GreyHoleDW >> asBox [
 	| reverb finalBox dry wet |
 	reverb := self inputL => GreyHole new.
 	dry := self inputL * (self dryWet - 1 asBox).
-	wet := (reverb asBox mergeWith: Wire new asBox) , self dryWet
+	wet := (reverb asBox mergeWith: Wire new asBox) , self dryWet asBox
 		       connectTo: PhMultiplier new.
 	finalBox := dry + wet.
 	^ finalBox

--- a/Phausto/Guitar.class.st
+++ b/Phausto/Guitar.class.st
@@ -43,7 +43,13 @@ Guitar >> initialize [
 
 	super initialize.
 	processExpression := 'process = pm.guitar;'.
-		trigger := PhButton new label: self label , 'Trigger'.
+	pluckPosition := (PhHSlider new
+					   label: self label , 'PluckPos'
+					   init: 0.8
+					   min: 0
+					   max: 1
+					   step: 0.01).
+	trigger := PhButton new label: self label , 'Trigger'.
 	self controlParameters add: #trigger -> (self trigger
 			 asControlParameterOfWidgetType: #button
 			 description: 'Trig Percussion')
@@ -52,13 +58,7 @@ Guitar >> initialize [
 { #category : 'accessing' }
 Guitar >> pluckPosition [
 
-	^ pluckPosition ifNil: [
-		  self pluckPosition: (PhHSlider new
-				   label: self label , 'PluckPos'
-				   init: 0.8
-				   min: 0
-				   max: 1
-				   step: 0.01) ]
+	^ pluckPosition 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/Hardclip.class.st
+++ b/Phausto/Hardclip.class.st
@@ -21,7 +21,7 @@ Hardclip >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Hardclip2.class.st
+++ b/Phausto/Hardclip2.class.st
@@ -21,7 +21,7 @@ Hardclip2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/HighPass.class.st
+++ b/Phausto/HighPass.class.st
@@ -1,0 +1,17 @@
+"
+Nth-order Butterworth highpass filter
+"
+Class {
+	#name : 'HighPass',
+	#superclass : 'ButterworthLPHP',
+	#category : 'Phausto-Filters',
+	#package : 'Phausto',
+	#tag : 'Filters'
+}
+
+{ #category : 'initialization' }
+HighPass >> initialize [
+
+	super initialize.
+	self processExpression: 'process = fi.highpass(4);'
+]

--- a/Phausto/Hyperbolic.class.st
+++ b/Phausto/Hyperbolic.class.st
@@ -21,7 +21,7 @@ Hyperbolic >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Hyperbolic2.class.st
+++ b/Phausto/Hyperbolic2.class.st
@@ -21,7 +21,7 @@ Hyperbolic2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Integrator.class.st
+++ b/Phausto/Integrator.class.st
@@ -16,7 +16,7 @@ Integrator >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := 1 asBox , self input connectTo: intermdiateBox.
+	finalBox := 1 asBox , self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Korg35HPF.class.st
+++ b/Phausto/Korg35HPF.class.st
@@ -24,11 +24,9 @@ Class {
 Korg35HPF >> asBox [
 
 	| intermdiateBox finalBox |
-	
+	intermdiateBox := super asBox.
 
-	intermdiateBox := super asBox .
-
-	finalBox := self fr , self res ,  self input connectTo: intermdiateBox.
+	finalBox := self fr asBox, self res asBox, self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Korg35LPF.class.st
+++ b/Phausto/Korg35LPF.class.st
@@ -24,11 +24,9 @@ Class {
 Korg35LPF >> asBox [
 
 	| intermdiateBox finalBox |
-	
+	intermdiateBox := super asBox.
 
-	intermdiateBox := super asBox .
-
-	finalBox := self fr , self res ,  self input connectTo: intermdiateBox.
+	finalBox := self fr asBox, self res asBox, self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/LFO.class.st
+++ b/Phausto/LFO.class.st
@@ -23,8 +23,8 @@ LFO >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self freq connectTo: intermediateBox.
-	^ finalBox 
+	finalBox := self freq asBox connectTo: intermediateBox.
+	^ finalBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/LFOForModulation.class.st
+++ b/Phausto/LFOForModulation.class.st
@@ -49,7 +49,7 @@ LFOForModulation >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self freq  connectTo: intermediateBox.
+	finalBox := self freq asBox connectTo: intermediateBox.
 	^ finalBox * self amount asBox + self offset asBox
 ]
 

--- a/Phausto/LimiterMono.class.st
+++ b/Phausto/LimiterMono.class.st
@@ -11,3 +11,8 @@ Class {
 	#package : 'Phausto',
 	#tag : 'Effects'
 }
+
+{ #category : 'converting' }
+LimiterMono >> asBox [ 
+self shouldBeImplemented 
+]

--- a/Phausto/Lowpass.class.st
+++ b/Phausto/Lowpass.class.st
@@ -18,11 +18,9 @@ Class {
 Lowpass >> asBox [
 
 	| intermdiateBox finalBox |
-	
+	intermdiateBox := super asBox.
 
-	intermdiateBox := super asBox .
-
-	finalBox := self cutoff , self input connectTo: intermdiateBox.
+	finalBox := self cutoff asBox, self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Lptn.class.st
+++ b/Phausto/Lptn.class.st
@@ -26,7 +26,8 @@ LptN >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self attenuation , self period , self input connectTo: intermdiateBox.
+	finalBox := self attenuation asBox, self period asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/MKOFilter.class.st
+++ b/Phausto/MKOFilter.class.st
@@ -1,5 +1,5 @@
 "
-Collection of _Moog_, _Korg_ _Oberheim_ style filters where:
+Collection of _Moog_, _Korg_ , _Oberheim_ style filters where:
 
 ## Parameters
 - **normFreq**: normalized frequency (0-1)
@@ -19,26 +19,33 @@ Class {
 	#tag : 'Filters'
 }
 
+{ #category : 'as yet unclassified' }
+MKOFilter >> initialize [
+
+	super initialize.
+	normFreq := PhHSlider new
+		            label: self label , 'NormFreq'
+		            init: 1
+		            min: 0
+		            max: 1
+		            step: 0.001.
+		
+	q := PhHSlider new
+				       label: self label , 'Q'
+				       init: 1
+				       min: 1
+				       max: 25
+				       step: 0.707 
+]
+
 { #category : 'accessing' }
 MKOFilter >> normFreq [
 
-	^ normFreq ifNil: [
-		  normFreq := PhHSlider new
-			        label: self label , 'NormFreq'
-			        init: 1
-			        min: 0
-			        max: 1
-			        step: 0.001 ]
+	^ normFreq 
 ]
 
 { #category : 'accessing' }
 MKOFilter >> q [
 
-	^ q ifNil: [
-		  q := PhHSlider new
-			       label: self label , 'Q'
-			       init: 1
-			       min: 1
-			       max: 25
-			       step: 0.707 ]
+	^ q 
 ]

--- a/Phausto/Marimba.class.st
+++ b/Phausto/Marimba.class.st
@@ -18,8 +18,9 @@ Marimba >> asBox [
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
-	finalBox := self freq , self strikePosition , self strikeCutoff , self  strikeSharpness
-	            , self gain , self trigger connectTo: intermediateBox.
+	finalBox := self freq asBox , self strikePosition asBox , self strikeCutoff asBox 
+	            , self strikeSharpness asBox , self gain asBox , self trigger asBox 
+		            connectTo: intermediateBox.
 
 	^ finalBox
 ]
@@ -30,16 +31,4 @@ Marimba >> initialize [
 	super initialize.
 	processExpression := 'process = pm.marimba;'.
 	
-]
-
-{ #category : 'accessing' }
-Marimba >> strikePosition [
-
-	^ strikePosition ifNil: [ 
-		self strikePosition: (PhHSlider new
-			 label: self label , 'StrikePos'
-			 init: 0
-			 min: 0
-			 max: 4
-			 step: 1). ]
 ]

--- a/Phausto/ModalModel.class.st
+++ b/Phausto/ModalModel.class.st
@@ -32,8 +32,8 @@ ModalModel >> asBox [
 	intermediateBox := super asBox.
 	"finalBox := self freqs asBox , self t60s asBox , self gains asBox
 	            , self input asBox connectTo: intermediateBox."
-	finalBox := 440 asBox , 0.5 asBox , 0.5 asBox , self input connectTo:
-		            intermediateBox.
+	finalBox := 440 asBox , 0.5 asBox , 0.5 asBox , self input asBox
+		            connectTo: intermediateBox.
 	^ intermediateBox
 ]
 
@@ -55,10 +55,10 @@ ModalModel >> initialize [
 
 	super initialize.
 	processExpression := 'process = pm.modalModel(1);'.
-	freqs := 440 asBox , 660 asBox.
-	t60s := 0.5 asBox , 0.25 asBox.
-	gains := 0.6 asBox , 0.8 asBox.
-	input := Pulse new period: 0.16 asBox
+	freqs := 440 asBox , 660 .
+	t60s := 0.5 asBox , 0.25 .
+	gains := 0.6 asBox , 0.8 .
+	input := Pulse new period: 0.16. 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/ModalPercussion.class.st
+++ b/Phausto/ModalPercussion.class.st
@@ -29,13 +29,7 @@ ModalPercussion >> freq [
 { #category : 'accessing' }
 ModalPercussion >> gain [
 
-	^ gain ifNil: [
-		  gain := PhHSlider new
-			          label: self label , 'Gain'
-			          init: 0.5
-			          min: 0
-			          max: 1
-			          step: 0.001 ]
+	^ gain 
 ]
 
 { #category : 'initialization' }
@@ -66,7 +60,13 @@ ModalPercussion >> initialize [
 		        min: 20
 		        max: 1200
 		        step: 1.
-self controlParameters add: #freq -> (self freq
+		gain := PhHSlider new
+				          label: self label , 'Gain'
+				          init: 0.5
+				          min: 0
+				          max: 1
+				          step: 0.001 .
+	self controlParameters add: #freq -> (self freq
 			 asControlParameterOfWidgetType: #knob
 			 description: 'Frequency in Hertz').
 	trigger := PhButton new label: self label , 'Trigger'.

--- a/Phausto/MoogHalfLadder.class.st
+++ b/Phausto/MoogHalfLadder.class.st
@@ -20,7 +20,8 @@ MoogHalfLadder >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox , self q asBox , self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/MoogLadder.class.st
+++ b/Phausto/MoogLadder.class.st
@@ -19,7 +19,8 @@ MoogLadder >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox, self q asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/MoogVcf.class.st
+++ b/Phausto/MoogVcf.class.st
@@ -22,11 +22,9 @@ Class {
 MoogVcf >> asBox [
 
 	| intermdiateBox finalBox |
-	
+	intermdiateBox := super asBox.
 
-	intermdiateBox := super asBox .
-
-	finalBox := self res , self fr ,  self input connectTo: intermdiateBox.
+	finalBox := self res asBox, self fr asBox , self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Oberheim.class.st
+++ b/Phausto/Oberheim.class.st
@@ -18,7 +18,8 @@ Oberheim >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox, self q asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/OberheimBPF.class.st
+++ b/Phausto/OberheimBPF.class.st
@@ -19,7 +19,8 @@ OberheimBPF >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox, self q asBox , self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/OberheimBSF.class.st
+++ b/Phausto/OberheimBSF.class.st
@@ -19,7 +19,8 @@ OberheimBSF >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox , self q asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/OberheimHPF.class.st
+++ b/Phausto/OberheimHPF.class.st
@@ -18,7 +18,8 @@ OberheimHPF >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox, self q asBox, self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/OberheimLPF.class.st
+++ b/Phausto/OberheimLPF.class.st
@@ -19,7 +19,8 @@ OberheimLPF >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self normFreq , self q , self input connectTo: intermdiateBox.
+	finalBox := self normFreq asBox , self q asBox , self input asBox connectTo:
+		            intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/OneZero.class.st
+++ b/Phausto/OneZero.class.st
@@ -24,7 +24,7 @@ OneZero >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self zero , self input connectTo: intermdiateBox.
+	finalBox := self zero asBox, self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Panner.class.st
+++ b/Phausto/Panner.class.st
@@ -24,7 +24,12 @@ Panner >> asBox [
 Panner >> initialize [
 
 	super initialize.
-	processExpression :='process = sp.panner;'.
-	
-	
+	processExpression := 'process = sp.panner;'.
+	input := Wire new.
+	pan :=  PhHSlider new
+				  label: self label , 'Pan'
+				  init: 0.5
+				  min: 0
+				  max: 1
+				  step: 0.001 
 ]

--- a/Phausto/Panner.class.st
+++ b/Phausto/Panner.class.st
@@ -16,7 +16,7 @@ Panner >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self pan , self input connectTo: intermediateBox.
+	finalBox := self pan asBox , self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Parabolic.class.st
+++ b/Phausto/Parabolic.class.st
@@ -21,7 +21,7 @@ Parabolic >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Parabolic2.class.st
+++ b/Phausto/Parabolic2.class.st
@@ -21,7 +21,7 @@ Parabolic2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/ParamsSetter.trait.st
+++ b/Phausto/ParamsSetter.trait.st
@@ -45,6 +45,18 @@ ParamsSetter >> amount: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'accessing' }
+ParamsSetter >> amplitude: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
 ParamsSetter >> ar: aNumberOrABoxOrASymbol [
 
 	| methodName |
@@ -310,6 +322,18 @@ ParamsSetter >> drive: aNumberOrABoxOrASymbol [
 
 { #category : 'accessing' }
 ParamsSetter >> dsfreq: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
+ParamsSetter >> duration: aNumberOrABoxOrASymbol [
 
 	| methodName |
 	methodName := thisContext selector. "Get the name of this method"

--- a/Phausto/ParamsSetter.trait.st
+++ b/Phausto/ParamsSetter.trait.st
@@ -213,6 +213,18 @@ ParamsSetter >> captureButton: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'accessing' }
+ParamsSetter >> cent: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
 ParamsSetter >> clockDivider: aNumberOrABoxOrASymbol [
 
 	| methodName |
@@ -799,6 +811,18 @@ ParamsSetter >> maxFreq: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'accessing' }
+ParamsSetter >> midiNN: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
 ParamsSetter >> modDepth:  aNumberOrABoxOrASymbol [
 
 	| methodName |
@@ -955,6 +979,18 @@ ParamsSetter >> pluckPosition: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'accessing' }
+ParamsSetter >> pole: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
 ParamsSetter >> poles: aNumberOrABoxOrASymbol [
 
 	| methodName |
@@ -1087,6 +1123,18 @@ ParamsSetter >> run: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'accessing' }
+ParamsSetter >> semitone:  aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
 ParamsSetter >> shift:  aNumberOrABoxOrASymbol [
 
 	| methodName |
@@ -1196,6 +1244,18 @@ ParamsSetter >> sustain: aNumberOrABoxOrASymbol [
 
 { #category : 'accessing' }
 ParamsSetter >> t60: aNumberOrABoxOrASymbol [
+
+	| methodName |
+	methodName := thisContext selector. "Get the name of this method"
+
+	methodName asString allButLast traceCr.
+	aNumberOrABoxOrASymbol
+		asParam: methodName asString allButLast
+		forUGen: self
+]
+
+{ #category : 'accessing' }
+ParamsSetter >> tau: aNumberOrABoxOrASymbol [
 
 	| methodName |
 	methodName := thisContext selector. "Get the name of this method"

--- a/Phausto/PhBeat.class.st
+++ b/Phausto/PhBeat.class.st
@@ -20,9 +20,9 @@ Class {
 	#instVars : [
 		'tempo'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -40,17 +40,17 @@ PhBeat >> asBox [
 PhBeat >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.beat;'
+	processExpression := 'process = ba.beat;'.
+	tempo := PhHSlider new
+		         label: self label , 'Tempo'
+		         init: 120
+		         min: 30
+		         max: 220
+		         step: 0.01
 ]
 
 { #category : 'accessing' }
 PhBeat >> tempo [
 
-	^ tempo ifNil: [
-		  tempo := PhHSlider new
-			           label: self label , 'Tempo'
-			           init: 120
-			           min: 30
-			           max: 220
-			           step: 0.01 ]
+	^ tempo 
 ]

--- a/Phausto/PhBox.class.st
+++ b/Phausto/PhBox.class.st
@@ -277,6 +277,11 @@ PhBox >> asDspWithName: aString [
 							^ finalDsp ] ]
 ]
 
+{ #category : 'converting' }
+PhBox >> asDspWithName: aString source: aUnitGenerator [ 
+	^ (self asDspWithName: aString )
+]
+
 { #category : 'printing' }
 PhBox >> asFaustCode [
 

--- a/Phausto/PhCent2Ratio.class.st
+++ b/Phausto/PhCent2Ratio.class.st
@@ -1,0 +1,35 @@
+"
+Converts semitone cents in a frequency multiplicative ratio.
+##Parameter
+
+**cent:** number of cents
+"
+Class {
+	#name : 'PhCent2Ratio',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'cent'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhCent2Ratio >> asBox [ 
+
+^ self cent asBox connectTo: super asBox.
+]
+
+{ #category : 'accessing' }
+PhCent2Ratio >> cent [
+^ cent
+]
+
+{ #category : 'accessing' }
+PhCent2Ratio >> initialize [ 
+
+super initialize .
+cent := 100.
+processExpression := 'process = ba.cent2ratio;'
+]

--- a/Phausto/PhClip.class.st
+++ b/Phausto/PhClip.class.st
@@ -18,7 +18,8 @@ PhClip >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self min , self max , self input connectTo: intermediateBox.
+	finalBox := self min  asBox, self max asBox , self input asBox connectTo:
+		            intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/PhConversionTool.class.st
+++ b/Phausto/PhConversionTool.class.st
@@ -1,0 +1,20 @@
+"
+Superclass for all Conversion tools
+"
+Class {
+	#name : 'PhConversionTool',
+	#superclass : 'UnitGenerator',
+	#instVars : [
+		'input'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'initialization' }
+PhConversionTool >> initialize [
+
+	super initialize.
+	input := Wire new.
+]

--- a/Phausto/PhCountDown.class.st
+++ b/Phausto/PhCountDown.class.st
@@ -2,7 +2,7 @@
 Starts counting up from 0 to n included. While trig is 1 the output is 0. The countup starts with the transition of trig from 1 to 0. At the end of the countup the output value will remain at n until the next trig. countup is a standard Faust function.
 "
 Class {
-	#name : 'CountUp',
+	#name : 'PhCountDown',
 	#superclass : 'UnitGenerator',
 	#instVars : [
 		'max',
@@ -14,38 +14,38 @@ Class {
 }
 
 { #category : 'converting' }
-CountUp >> asBox [
+PhCountDown >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
 
-	finalBox := self max asBox  , self trig asBox connectTo: intermediateBox.
+	finalBox := self max asBox , self trig asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
 { #category : 'initialization' }
-CountUp >> initialize [
+PhCountDown >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.countup;'.
+	processExpression := 'process = ba.countdown;'.
 	max := PhHSlider new
 		       label: self label , 'Max'
 		       init: 1
 		       min: 1
 		       max: 64
 		       step: 1.
-	trig := PhButton new label: self label , 'Gate'
+		trig := PhButton new label: self label , 'Gate'
 ]
 
 { #category : 'as yet unclassified' }
-CountUp >> max [
+PhCountDown >> max [
 
 	^ max 
 ]
 
 { #category : 'accessing' }
-CountUp >> trig [
+PhCountDown >> trig [
 
 	^ trig 
 ]

--- a/Phausto/PhCountUp.class.st
+++ b/Phausto/PhCountUp.class.st
@@ -2,7 +2,7 @@
 Starts counting up from 0 to n included. While trig is 1 the output is 0. The countup starts with the transition of trig from 1 to 0. At the end of the countup the output value will remain at n until the next trig. countup is a standard Faust function.
 "
 Class {
-	#name : 'CountDown',
+	#name : 'PhCountUp',
 	#superclass : 'UnitGenerator',
 	#instVars : [
 		'max',
@@ -14,38 +14,38 @@ Class {
 }
 
 { #category : 'converting' }
-CountDown >> asBox [
+PhCountUp >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
 
-	finalBox := self max asBox , self trig asBox connectTo: intermediateBox.
+	finalBox := self max asBox  , self trig asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
 { #category : 'initialization' }
-CountDown >> initialize [
+PhCountUp >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.countdown;'.
+	processExpression := 'process = ba.countup;'.
 	max := PhHSlider new
 		       label: self label , 'Max'
 		       init: 1
 		       min: 1
 		       max: 64
 		       step: 1.
-		trig := PhButton new label: self label , 'Gate'
+	trig := PhButton new label: self label , 'Gate'
 ]
 
 { #category : 'as yet unclassified' }
-CountDown >> max [
+PhCountUp >> max [
 
 	^ max 
 ]
 
 { #category : 'accessing' }
-CountDown >> trig [
+PhCountUp >> trig [
 
 	^ trig 
 ]

--- a/Phausto/PhCounter.class.st
+++ b/Phausto/PhCounter.class.st
@@ -42,13 +42,7 @@ PhCounter >> initialize [
 { #category : 'accessing' }
 PhCounter >> max [
 
-	^ max ifNil: [
-		  max := PhHSlider new
-			         label: self label , 'Max'
-			         init: self maxValue
-			         min: 1
-			         max: self maxValue
-			         step: 1 ]
+	^ max 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/PhCycle.class.st
+++ b/Phausto/PhCycle.class.st
@@ -11,9 +11,9 @@ Class {
 		'n',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -23,7 +23,7 @@ PhCycle >> asBox [
 	intermediateBox := super asBox.
 
 
-	finalBox := self n , self input  connectTo: intermediateBox.
+	finalBox := self n asBox , self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 
@@ -31,23 +31,24 @@ PhCycle >> asBox [
 PhCycle >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.cycle;'
+	processExpression := 'process = ba.cycle;'.
+	input := SquareOsc new.
+	n := PhHSlider new
+				       label: self label , 'N'
+				       init: 1
+				       min: 1
+				       max: 88200
+				       step: 1 
 ]
 
 { #category : 'accessing' }
 PhCycle >> input [
 
-	^ input ifNil: [ input := SquareOsc new ]
+	^ input 
 ]
 
 { #category : 'as yet unclassified' }
 PhCycle >> n [
 
-	^ n ifNil: [
-		  n := PhHSlider new
-			            label: self label , 'N'
-			            init: 1
-			            min: 1
-			            max: 88200
-			            step: 1 ]
+	^ n 
 ]

--- a/Phausto/PhDb2Linear.class.st
+++ b/Phausto/PhDb2Linear.class.st
@@ -1,0 +1,37 @@
+"
+dB-to-linear value converter. 
+It can be used to convert an amplitude in dB to a linear gain ]0-N.
+Learn more about [decibels](https://en.wikipedia.org/wiki/Decibel)
+##Parameter
+**amplitude:** amplitude in decibel.
+"
+Class {
+	#name : 'PhDb2Linear',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'amplitude'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhDb2Linear >> amplitude [ 
+^ amplitude
+]
+
+{ #category : 'converting' }
+PhDb2Linear >> asBox [
+
+	^ self amplitude asBox connectTo: super asBox
+]
+
+{ #category : 'initialization' }
+PhDb2Linear >> initialize [
+
+	super initialize.
+	amplitude := 1.
+
+	processExpression := 'process = ba.db2linear;'
+]

--- a/Phausto/PhFilter.class.st
+++ b/Phausto/PhFilter.class.st
@@ -29,5 +29,5 @@ PhFilter >> input [
 { #category : 'connecting' }
 PhFilter >> patchedWith: aUnitGenerator [
 
-self  input: aUnitGenerator asBox
+	self input: aUnitGenerator 
 ]

--- a/Phausto/PhFilter.class.st
+++ b/Phausto/PhFilter.class.st
@@ -14,16 +14,17 @@ Class {
 	#tag : 'Filters'
 }
 
+{ #category : 'initialization' }
+PhFilter >> initialize [
+
+	super initialize.
+	input := Wire new.
+]
+
 { #category : 'accessing' }
 PhFilter >> input [
 
-	^ input ifNil:  [
-		  input  := PhHSlider new
-			          label: self label , 'Input'
-			          init: 5000
-			          min: 20
-			          max: 18000
-			          step: 1 ] 
+	^ input 
 ]
 
 { #category : 'connecting' }

--- a/Phausto/PhHz2MidiKey.class.st
+++ b/Phausto/PhHz2MidiKey.class.st
@@ -1,0 +1,36 @@
+"
+Converts a frequency in Hz to a MIDI key number (440 Hz = MIDI key 69).
+
+##Parameter
+
+**freq:** frequency  in Hertz
+"
+Class {
+	#name : 'PhHz2MidiKey',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'freq'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhHz2MidiKey >> asBox [ 
+
+self freq asBox connectTo: super asBox 
+]
+
+{ #category : 'accessing' }
+PhHz2MidiKey >> freq [ 
+^ freq
+]
+
+{ #category : 'accessing' }
+PhHz2MidiKey >> initialize [
+
+	super initialize.
+	freq := 440.
+	processExpression := 'process = ba.hz2midikey;'
+]

--- a/Phausto/PhHz2PianoKey.class.st
+++ b/Phausto/PhHz2PianoKey.class.st
@@ -1,0 +1,37 @@
+"
+Converts a frequency in Hz to a MIDI key number (440 Hz = MIDI key 69).
+
+##Parameter
+
+**freq:** frequency  in Hertz
+"
+Class {
+	#name : 'PhHz2PianoKey',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'freq'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhHz2PianoKey >> asBox [
+
+	self freq asBox connectTo: super asBox
+]
+
+{ #category : 'converting' }
+PhHz2PianoKey >> freq [ 
+
+^ freq
+]
+
+{ #category : 'initialization' }
+PhHz2PianoKey >> initialize [
+
+	super initialize.
+	freq := 440.
+	processExpression := 'process = ba.hz2pianokey;'
+]

--- a/Phausto/PhLinear2Db.class.st
+++ b/Phausto/PhLinear2Db.class.st
@@ -21,7 +21,7 @@ Class {
 { #category : 'converting' }
 PhLinear2Db >> asBox [ 
 
-^ self gain connectTo: super asBox
+^ self gain asBox  connectTo: super asBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/PhLinear2Db.class.st
+++ b/Phausto/PhLinear2Db.class.st
@@ -1,0 +1,39 @@
+"
+linear-to-dB value converter. It can be used to convert a linear gain ]0-N] to an amplitude in dB.
+More about [decibels](https://en.wikipedia.org/wiki/Decibel)
+
+
+##Parameter
+**gain:** a linear gain
+
+"
+Class {
+	#name : 'PhLinear2Db',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'gain'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhLinear2Db >> asBox [ 
+
+^ self gain connectTo: super asBox
+]
+
+{ #category : 'accessing' }
+PhLinear2Db >> gain [ 
+^ gain
+]
+
+{ #category : 'initialization' }
+PhLinear2Db >> initialize [
+
+	super initialize.
+	gain := 1.
+
+	processExpression := 'process = ba.linear2db;'
+]

--- a/Phausto/PhLinear2LogGain.class.st
+++ b/Phausto/PhLinear2LogGain.class.st
@@ -1,0 +1,36 @@
+"
+Converts a linear gain (0-1) to a log gain (0-1).
+
+##Parameter
+**gain:** the linear gain
+"
+Class {
+	#name : 'PhLinear2LogGain',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'gain'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhLinear2LogGain >> asBox [ 
+
+self gain asBox  connectTo: super asBox
+]
+
+{ #category : 'accessing' }
+PhLinear2LogGain >> gain [ 
+
+^ gain
+]
+
+{ #category : 'initialization' }
+PhLinear2LogGain >> initialize [ 
+
+super initialize .
+gain:= 1.
+processExpression := 'process = ba.lin2LogGain;'
+]

--- a/Phausto/PhLog2LinearGain.class.st
+++ b/Phausto/PhLog2LinearGain.class.st
@@ -1,0 +1,37 @@
+"
+Converts a log gain (0-1) to a linear gain (0-1).
+
+##Parameter
+
+**gain:** the log gain
+"
+Class {
+	#name : 'PhLog2LinearGain',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'gain'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhLog2LinearGain >> asBox [
+
+	self gain asBox connectTo: super asBox
+]
+
+{ #category : 'converting' }
+PhLog2LinearGain >> gain [
+
+^ gain
+]
+
+{ #category : 'initialization' }
+PhLog2LinearGain >> initialize [
+
+	super initialize.
+	gain := 1.
+	processExpression := 'process = ba.log2LinGain;'
+]

--- a/Phausto/PhMidiKey2Hz.class.st
+++ b/Phausto/PhMidiKey2Hz.class.st
@@ -1,0 +1,36 @@
+"
+Converts a MIDI key number to a frequency in Hz (MIDI key 69 = 440 Hz).
+
+##Parameter
+**midiNN:** the MIDI key number
+"
+Class {
+	#name : 'PhMidiKey2Hz',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'midiNN'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhMidiKey2Hz >> asBox [ 
+
+^ self midiNN asBox connectTo: super asBox 
+]
+
+{ #category : 'accessing' }
+PhMidiKey2Hz >> initialize [
+
+	super initialize.
+	midiNN := 69.
+	processExpression := 'process = ba.midikey2hz;'
+]
+
+{ #category : 'accessing' }
+PhMidiKey2Hz >> midiNN [ 
+
+^ midiNN
+]

--- a/Phausto/PhPeriod.class.st
+++ b/Phausto/PhPeriod.class.st
@@ -11,19 +11,19 @@ Class {
 	#instVars : [
 		'period'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
 PhPeriod >> asBox [
 
-	| intermediateBox  finalBox |
+	| intermediateBox finalBox |
 	intermediateBox := super asBox.
 
 
-	finalBox := self period connectTo: intermediateBox.
+	finalBox := self period asBox  connectTo: intermediateBox.
 	^ finalBox
 ]
 
@@ -31,17 +31,17 @@ PhPeriod >> asBox [
 PhPeriod >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.period;'
+	processExpression := 'process = ba.period;'.
+	period := PhHSlider new
+		          label: self label , 'Period'
+		          init: 1
+		          min: 0.1
+		          max: 10
+		          step: 0.01
 ]
 
 { #category : 'accessing' }
 PhPeriod >> period [
 
-	^ period ifNil: [
-		  period := PhHSlider new
-			            label: self label , 'Period'
-			            init: 1
-			            min: 0.1
-			            max: 10
-			            step: 0.01 ]
+	^ period
 ]

--- a/Phausto/PhPianoKey2Hz.class.st
+++ b/Phausto/PhPianoKey2Hz.class.st
@@ -1,0 +1,36 @@
+"
+Converts a MIDI key number to a frequency in Hz (MIDI key 69 = 440 Hz).
+
+##Parameter
+**midiNN:** the MIDI key number
+"
+Class {
+	#name : 'PhPianoKey2Hz',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'midiNN'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhPianoKey2Hz >> asBox [
+
+	^ self midiNN asBox connectTo: super asBox
+]
+
+{ #category : 'initialization' }
+PhPianoKey2Hz >> initialize [
+
+	super initialize.
+	midiNN := 69.
+	processExpression := 'process = ba.pianokey2hz;'
+]
+
+{ #category : 'accessing' }
+PhPianoKey2Hz >> midiNN [ 
+
+^ midiNN 
+]

--- a/Phausto/PhPole2tau.class.st
+++ b/Phausto/PhPole2tau.class.st
@@ -1,0 +1,38 @@
+"
+Returns the time-constant, in seconds, corresponding to the given real, positive pole in (0-1).
+The function is typically used in scenarios where you need to analyze or design a system's response characteristics. By converting a pole position to a time constant, you can better understand how fast the system will react to inputs or how quickly it will reach a steady state.
+
+##Parameter
+
+**pole:** the pole
+"
+Class {
+	#name : 'PhPole2tau',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'pole'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhPole2tau >> asBox [ 
+
+self pole asBox connectTo: super asBox
+]
+
+{ #category : 'converting' }
+PhPole2tau >> initialize [
+
+	super initialize.
+   pole := 0.
+	processExpression := 'process = ba.pole2tau;'
+]
+
+{ #category : 'accessing' }
+PhPole2tau >> pole [ 
+
+^ pole
+]

--- a/Phausto/PhRamp.class.st
+++ b/Phausto/PhRamp.class.st
@@ -1,20 +1,20 @@
 "
 A linear ramp with a slope of '(+/-)1/n' samples to reach the next target value.
 
-Parameter
-n: number of samples to increment/decrement the value by one
+## Parameters
+**input:** increment the ramp when > 0 , decrement when < 0 , reset the ramp when equals to 0.
+**n:** number of samples to increment/decrement the value by one
 "
 Class {
 	#name : 'PhRamp',
 	#superclass : 'UnitGenerator',
 	#instVars : [
-		'trig',
 		'n',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -32,29 +32,24 @@ PhRamp >> asBox [
 PhRamp >> initialize [
 
 	super initialize.
-	processExpression := 'process = ba.ramp;'
+	processExpression := 'process = ba.ramp;'.
+	n := PhHSlider new
+		     label: self label , 'N'
+		     init: 1
+		     min: 1
+		     max: 88200
+		     step: 1.
+	input := PhButton new label: self label , 'Gate'.
 ]
 
 { #category : 'as yet unclassified' }
 PhRamp >> input [
 
-	^ input ifNil: [
-		  input := PhHSlider new
-			           label: self label , 'Input'
-			           init: 5000
-			           min: 20
-			           max: 18000
-			           step: 1 ]
+	^ input 
 ]
 
 { #category : 'as yet unclassified' }
 PhRamp >> n [
 
-	^ n ifNil: [
-		  n := PhHSlider new
-			            label: self label , 'N'
-			            init: 1
-			            min: 1
-			            max: 88200
-			            step: 1 ]
+	^ n 
 ]

--- a/Phausto/PhRatio2Cent.class.st
+++ b/Phausto/PhRatio2Cent.class.st
@@ -1,0 +1,36 @@
+"
+Converts a frequency multiplicative ratio in semitone cents.
+##Parameter
+
+**ratio:** frequence multiplicative in ratio
+"
+Class {
+	#name : 'PhRatio2Cent',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'ratio'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhRatio2Cent >> asBox [ 
+
+^ self ratio asBox connectTo: super asBox
+]
+
+{ #category : 'initialization' }
+PhRatio2Cent >> initialize [
+
+	super initialize.
+	ratio := 1.
+	processExpression := 'ba.ratio2cent;'
+]
+
+{ #category : 'accessing' }
+PhRatio2Cent >> ratio [ 
+
+^ ratio
+]

--- a/Phausto/PhRatio2Semitone.class.st
+++ b/Phausto/PhRatio2Semitone.class.st
@@ -1,0 +1,34 @@
+"
+Converts a frequency multiplicative ratio in semitones.
+##Parameter
+
+**ratio:** frequence multiplicative in ratio
+"
+Class {
+	#name : 'PhRatio2Semitone',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'ratio'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhRatio2Semitone >> asBox [ 
+^ self ratio asBox connectTo: super asBox 
+]
+
+{ #category : 'initialization' }
+PhRatio2Semitone >> initialize [
+
+	super initialize.
+	ratio := 1.
+	processExpression := 'process = ba.ratio2semi;'
+]
+
+{ #category : 'converting' }
+PhRatio2Semitone >> ratio [ 
+^ ratio 
+]

--- a/Phausto/PhReaderWithSpeed.class.st
+++ b/Phausto/PhReaderWithSpeed.class.st
@@ -17,7 +17,7 @@ Class {
 PhReaderWithSpeed >> asBox [
 
 	| sum resetter |
-	resetter := (Resetter new trigger: self trigger) asBox.
+	resetter := (PhResetter new trigger: self trigger) asBox.
 	sum := Wire new asBox + self speed.
 	^ resetter ~ sum
 ]

--- a/Phausto/PhResetCtr.class.st
+++ b/Phausto/PhResetCtr.class.st
@@ -6,7 +6,7 @@ totalImpulses = the total number of impulses being split.
 impulseIndex =  index of impulse to allow to be output
 "
 Class {
-	#name : 'ResetCtr',
+	#name : 'PhResetCtr',
 	#superclass : 'UnitGenerator',
 	#instVars : [
 		'totalImpulses',
@@ -19,7 +19,7 @@ Class {
 }
 
 { #category : 'converting' }
-ResetCtr >> asBox [
+PhResetCtr >> asBox [
 
 	| intermediateBox  finalBox |
 	intermediateBox := super asBox.
@@ -30,7 +30,7 @@ ResetCtr >> asBox [
 ]
 
 { #category : 'initialization' }
-ResetCtr >> impulseIndex [
+PhResetCtr >> impulseIndex [
 
 	^ impulseIndex ifNil: [
 		  impulseIndex := PhHSlider new
@@ -42,7 +42,7 @@ ResetCtr >> impulseIndex [
 ]
 
 { #category : 'initialization' }
-ResetCtr >> initialize [
+PhResetCtr >> initialize [
 
 	super initialize.
 	processExpression := 'process = ba.resetCtr;'.
@@ -51,14 +51,14 @@ ResetCtr >> initialize [
 ]
 
 { #category : 'initialization' }
-ResetCtr >> input [
+PhResetCtr >> input [
 
 	^ input ifNil: [
 		  input := 0 asBox ]
 ]
 
 { #category : 'initialization' }
-ResetCtr >> totalImpulses [
+PhResetCtr >> totalImpulses [
 
 	^ totalImpulses ifNil: [
 		  totalImpulses := PhHSlider new

--- a/Phausto/PhResetter.class.st
+++ b/Phausto/PhResetter.class.st
@@ -2,7 +2,7 @@
 I am a Resetter, when triggered,  I set my value to 0. My other input is a Wire, as I am dsigned to be used in a SampleFile or Wavetable reader
 "
 Class {
-	#name : 'Resetter',
+	#name : 'PhResetter',
 	#superclass : 'PhBox',
 	#instVars : [
 		'trigger'
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : 'converting' }
-Resetter >> asBox [
+PhResetter >> asBox [
 
 	| oneSampleTrig samp |
 	samp := (1 / 48000) asFloat asBox.
@@ -28,20 +28,20 @@ Resetter >> asBox [
 ]
 
 { #category : 'initialization' }
-Resetter >> initialize [ 
+PhResetter >> initialize [ 
 
 super initialize.
 self trigger: 0 
 ]
 
 { #category : 'accessing' }
-Resetter >> trigger [
+PhResetter >> trigger [
 
 	^ trigger
 ]
 
 { #category : 'accessing' }
-Resetter >> trigger: aTrigger [ 
+PhResetter >> trigger: aTrigger [ 
 
 	trigger := aTrigger asBox
 ]

--- a/Phausto/PhSamp2Sec.class.st
+++ b/Phausto/PhSamp2Sec.class.st
@@ -1,0 +1,37 @@
+"
+Converts a number of samples to a duration in seconds at the current sampling rate . 
+## Parameters
+**duration:** duration in seconds
+"
+Class {
+	#name : 'PhSamp2Sec',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'duration',
+		'amplitude'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'converting' }
+PhSamp2Sec >> asBox [
+
+	^ self duration asBox connectTo: super asBox
+]
+
+{ #category : 'accessing' }
+PhSamp2Sec >> duration [
+
+^ duration
+]
+
+{ #category : 'initialization' }
+PhSamp2Sec >> initialize [
+
+	super initialize.
+	duration := 44100.
+
+	processExpression := 'process = ba.samp2sec;'
+]

--- a/Phausto/PhSec2Samp.class.st
+++ b/Phausto/PhSec2Samp.class.st
@@ -1,10 +1,10 @@
 "
-Converts a number of samples to a duration in seconds at the current sampling rate . 
+Converts a duration in seconds to a number of samples at the current sampling rate
 ## Parameters
 **duration:** duration in seconds
 "
 Class {
-	#name : 'PhSamp2Sec',
+	#name : 'PhSec2Samp',
 	#superclass : 'PhConversionTool',
 	#instVars : [
 		'duration'
@@ -14,23 +14,22 @@ Class {
 	#tag : 'Basics - ConversionTools'
 }
 
-{ #category : 'converting' }
-PhSamp2Sec >> asBox [
+{ #category : 'accessing' }
+PhSec2Samp >> asBox [ 
 
-	^ self duration asBox connectTo: super asBox
+^ self duration asBox connectTo: super asBox.
 ]
 
 { #category : 'accessing' }
-PhSamp2Sec >> duration [
+PhSec2Samp >> duration [
 
 ^ duration
 ]
 
 { #category : 'initialization' }
-PhSamp2Sec >> initialize [
+PhSec2Samp >> initialize [
 
 	super initialize.
-	duration := 44100.
-
-	processExpression := 'process = ba.samp2sec;'
+	duration := 1.
+	processExpression := 'process = ba.sec2samp;'
 ]

--- a/Phausto/PhSemi2Ratio.class.st
+++ b/Phausto/PhSemi2Ratio.class.st
@@ -1,0 +1,36 @@
+"
+Converts semitones in a frequency multiplicative ratio.
+
+##Parameter
+**semitone:** number of semitones
+"
+Class {
+	#name : 'PhSemi2Ratio',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'semitone'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhSemi2Ratio >> asBox [ 
+
+self semitone asBox connectTo: super asBox.
+]
+
+{ #category : 'initialization' }
+PhSemi2Ratio >> initialize [ 
+
+super initialize .
+semitone := 12.
+processExpression := 'process = ba.semi2ratio;'
+]
+
+{ #category : 'accessing' }
+PhSemi2Ratio >> semitone [
+
+^ semitone
+]

--- a/Phausto/PhSweep.class.st
+++ b/Phausto/PhSweep.class.st
@@ -3,7 +3,7 @@ Counts from 0 to period-1 repeatedly, generating a sawtooth waveform, like os.lf
 Period is expressed in seconds
 "
 Class {
-	#name : 'Sweep',
+	#name : 'PhSweep',
 	#superclass : 'UnitGenerator',
 	#instVars : [
 		'period',
@@ -15,7 +15,7 @@ Class {
 }
 
 { #category : 'converting' }
-Sweep >> asBox [
+PhSweep >> asBox [
 
 	| intermediateBox periodInSamples finalBox |
 	intermediateBox := super asBox.
@@ -27,14 +27,14 @@ Sweep >> asBox [
 ]
 
 { #category : 'initialization' }
-Sweep >> initialize [
+PhSweep >> initialize [
 
 	super initialize.
 	processExpression := 'process = ba.sweep;'
 ]
 
 { #category : 'accessing' }
-Sweep >> period [
+PhSweep >> period [
 
 	^ period ifNil: [
 		  period := PhHSlider new
@@ -46,7 +46,7 @@ Sweep >> period [
 ]
 
 { #category : 'as yet unclassified' }
-Sweep >> period: aNumberOrABoxOrASymbol [
+PhSweep >> period: aNumberOrABoxOrASymbol [
 
 	| methodName |
 	methodName := thisContext selector.
@@ -58,7 +58,7 @@ Sweep >> period: aNumberOrABoxOrASymbol [
 ]
 
 { #category : 'as yet unclassified' }
-Sweep >> run [
+PhSweep >> run [
 
 	^ run ifNil: [ run := PhButton new label: self label , 'Gate' ]
 ]

--- a/Phausto/PhTau2Pole.class.st
+++ b/Phausto/PhTau2Pole.class.st
@@ -1,0 +1,37 @@
+"
+Returns a real pole giving exponential decay. Note that t60 (time to decay 60 dB) is ~6.91 time constants.
+
+##Parameter
+
+**tau:** time-constant in seconds
+"
+Class {
+	#name : 'PhTau2Pole',
+	#superclass : 'PhConversionTool',
+	#instVars : [
+		'tau'
+	],
+	#category : 'Phausto-Basics - ConversionTools',
+	#package : 'Phausto',
+	#tag : 'Basics - ConversionTools'
+}
+
+{ #category : 'accessing' }
+PhTau2Pole >> asBox [ 
+
+^ self tau asBox connectTo: super asBox
+]
+
+{ #category : 'accessing' }
+PhTau2Pole >> initialize [
+
+	super initialize.
+	tau :=1.
+	processExpression := 'process = ba.tau2pole;'
+]
+
+{ #category : 'accessing' }
+PhTau2Pole >> tau [ 
+
+^ tau
+]

--- a/Phausto/PhTempo.class.st
+++ b/Phausto/PhTempo.class.st
@@ -12,9 +12,9 @@ Class {
 		'trig',
 		'tempo'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }
@@ -24,7 +24,7 @@ PhTempo >> asBox [
 	intermediateBox := super asBox.
 
 
-	finalBox := self tempo connectTo: intermediateBox.
+	finalBox := self tempo asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/PhTime.class.st
+++ b/Phausto/PhTime.class.st
@@ -7,9 +7,9 @@ Class {
 	#instVars : [
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'initialization' }

--- a/Phausto/PhTkCounter.class.st
+++ b/Phausto/PhTkCounter.class.st
@@ -3,7 +3,7 @@ I am a Phausto counter, I count from 1 to maxValue when triggered.
 By default, I count to 8 and I am triggered by a Button
 "
 Class {
-	#name : 'PhCounter',
+	#name : 'PhTkCounter',
 	#superclass : 'UnitGenerator',
 	#instVars : [
 		'trigger',
@@ -16,7 +16,7 @@ Class {
 }
 
 { #category : 'converting' }
-PhCounter >> asBox [
+PhTkCounter >> asBox [
 
 	| count finalBox |
 	count := Counter new trig: self trigger.
@@ -26,7 +26,7 @@ PhCounter >> asBox [
 ]
 
 { #category : 'initialization' }
-PhCounter >> initialize [
+PhTkCounter >> initialize [
 
 	super initialize.
 	maxValue := 8.
@@ -40,18 +40,18 @@ PhCounter >> initialize [
 ]
 
 { #category : 'accessing' }
-PhCounter >> max [
+PhTkCounter >> max [
 
 	^ max 
 ]
 
 { #category : 'accessing' }
-PhCounter >> maxValue [
+PhTkCounter >> maxValue [
 ^ maxValue
 ]
 
 { #category : 'accessing' }
-PhCounter >> trigger [
+PhTkCounter >> trigger [
 
 	^ trigger 
 ]

--- a/Phausto/PhysicalModelTest.class.st
+++ b/Phausto/PhysicalModelTest.class.st
@@ -73,6 +73,18 @@ PhysicalModelTest >> testPluckStringAsDsp [
 ]
 
 { #category : 'tests' }
+PhysicalModelTest >> testSFFormantModelBPAsDsp [
+
+	self deny: SFFormantModelBP new asDsp isNull
+]
+
+{ #category : 'tests' }
+PhysicalModelTest >> testSFFormantModelFofCycleAsDsp [
+
+	self deny: SFFormantModelFofCycle new asDsp isNull
+]
+
+{ #category : 'tests' }
 PhysicalModelTest >> testStrikeAsDsp [
 
 	self assert: Strike new asDsp isNull equals: false

--- a/Phausto/Pole.class.st
+++ b/Phausto/Pole.class.st
@@ -24,7 +24,7 @@ Pole >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self pole ,self input connectTo: intermdiateBox.
+	finalBox := self pole asBox , self input connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Pulse.class.st
+++ b/Phausto/Pulse.class.st
@@ -7,9 +7,9 @@ Class {
 	#instVars : [
 		'period'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/PulseCountDown.class.st
+++ b/Phausto/PulseCountDown.class.st
@@ -12,9 +12,9 @@ Class {
 		'max',
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/PulseCountDownLoop.class.st
+++ b/Phausto/PulseCountDownLoop.class.st
@@ -15,9 +15,9 @@ Class {
 		'n',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/PulseCountUp.class.st
+++ b/Phausto/PulseCountUp.class.st
@@ -12,9 +12,9 @@ Class {
 		'max',
 		'trig'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/PulseCountUpLoop.class.st
+++ b/Phausto/PulseCountUpLoop.class.st
@@ -15,9 +15,9 @@ Class {
 		'n',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/PulseGate.class.st
+++ b/Phausto/PulseGate.class.st
@@ -13,7 +13,7 @@ For example, if m = 1 and n = 4, PulseGate will pass through only the first puls
 "
 Class {
 	#name : 'PulseGate',
-	#superclass : 'ResetCtr',
+	#superclass : 'PhResetCtr',
 	#instVars : [
 		'period'
 	],
@@ -27,7 +27,7 @@ PulseGate >> asBox [
 
 | impulseGenerator  resetCtr |
 impulseGenerator := Pulse new period: self period.
-resetCtr := ResetCtr new input: impulseGenerator.
+resetCtr := PhResetCtr new input: impulseGenerator.
 ^ resetCtr asBox 
 
 

--- a/Phausto/PulseOsc.class.st
+++ b/Phausto/PulseOsc.class.st
@@ -40,8 +40,9 @@ PulseOsc >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self freq , self duty connectTo: intermediateBox.
-	^ finalBox * self uLevel
+	finalBox := self freq asBox , self duty asBox connectTo:
+		            intermediateBox.
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'accessing' }

--- a/Phausto/Pulsen.class.st
+++ b/Phausto/Pulsen.class.st
@@ -8,9 +8,9 @@ Class {
 		'length',
 		'period'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/ResetCtr.class.st
+++ b/Phausto/ResetCtr.class.st
@@ -13,9 +13,9 @@ Class {
 		'impulseIndex',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/ResonatorFilter.class.st
+++ b/Phausto/ResonatorFilter.class.st
@@ -30,7 +30,7 @@ ResonatorFilter >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self frequency smoo , self q , self gain , self input
+	finalBox := self frequency smoo , self q asBox, self gain asBox , self input asBox
 		            connectTo: intermdiateBox.
 
 	^ finalBox

--- a/Phausto/ResonatorFilter.class.st
+++ b/Phausto/ResonatorFilter.class.st
@@ -30,8 +30,8 @@ ResonatorFilter >> asBox [
 	| intermdiateBox finalBox |
 	intermdiateBox := super asBox.
 
-	finalBox := self frequency smoo , self q asBox, self gain asBox , self input asBox
-		            connectTo: intermdiateBox.
+	finalBox := self frequency asBox smoo , self q asBox , self gain asBox
+	            , self input asBox connectTo: intermdiateBox.
 
 	^ finalBox
 ]

--- a/Phausto/RussianBell.class.st
+++ b/Phausto/RussianBell.class.st
@@ -20,9 +20,9 @@ RussianBell >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-
-	finalBox := self strikePosition , self strikeCutoff , self strikeSharpness , self gain
-	            , self trigger connectTo: intermediateBox.
+	finalBox := self strikePosition asBox , self strikeCutoff asBox
+	            , self strikeSharpness asBox , self gain asBox
+	            , self trigger asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/SFFormantModelBP.class.st
+++ b/Phausto/SFFormantModelBP.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : 'SFFormantModelBP',
+	#superclass : 'FormantSynthesis',
+	#category : 'Phausto-PhysicalModels',
+	#package : 'Phausto',
+	#tag : 'PhysicalModels'
+}
+
+{ #category : 'initialization' }
+SFFormantModelBP >> initialize [
+
+processExpression := 'process = pm.SFFormantModelBP;'
+]

--- a/Phausto/SFFormantModelBP.class.st
+++ b/Phausto/SFFormantModelBP.class.st
@@ -1,3 +1,6 @@
+"
+Simple formant/vocal synthesizer based on a source/filter model. The source is just a sawtooth wave and the ""filter"" is a bank of resonant bandpass filters. Formant parameters are linearly interpolated allowing to go smoothly from one vowel to another. Voice type can be selected but must correspond to the frequency range of the synthesized voice to be realistic.
+"
 Class {
 	#name : 'SFFormantModelBP',
 	#superclass : 'FormantSynthesis',
@@ -9,5 +12,6 @@ Class {
 { #category : 'initialization' }
 SFFormantModelBP >> initialize [
 
-processExpression := 'process = pm.SFFormantModelBP;'
+super initialize.
+	processExpression := 'process = pm.SFFormantModelBP;'
 ]

--- a/Phausto/SFFormantModelBP_ui.class.st
+++ b/Phausto/SFFormantModelBP_ui.class.st
@@ -14,6 +14,13 @@ super asBox
 ]
 
 { #category : 'initialization' }
+SFFormantModelBP_ui >> initialize [
+
+	super initialize.
+	processExpression := 'process = pm.SFFormantModelBP_ui;'
+]
+
+{ #category : 'initialization' }
 SFFormantModelBP_ui >> initializeULevel [ 
 super initialize.
 processExpression := 'process = pm.SFFormantModelBP_ui;'

--- a/Phausto/SatRev.class.st
+++ b/Phausto/SatRev.class.st
@@ -14,9 +14,9 @@ Class {
 { #category : 'converting' }
 SatRev >> asBox [
 
-| intermediateBox finalBox |
-intermediateBox := super asBox.
-finalBox := self input connectTo: intermediateBox.
+	| intermediateBox finalBox |
+	intermediateBox := super asBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/SawOsc.class.st
+++ b/Phausto/SawOsc.class.st
@@ -17,10 +17,9 @@ Class {
 SawOsc >> asBox [
 
 	| intermediateBox finalBox |
-
 	intermediateBox := super asBox.
 	finalBox := self freq asBox connectTo: intermediateBox.
-	^ finalBox * self uLevel
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'initialization' }

--- a/Phausto/SimpleDelay.class.st
+++ b/Phausto/SimpleDelay.class.st
@@ -14,9 +14,9 @@ SimpleDelay >> asBox [
 
 	| intermediateBox finalBox delayInSamples |
 	intermediateBox := super asBox.
-	delayInSamples := self delayLength * PhSampleRate new.
-	finalBox := self maxDelayLength asBox , delayInSamples asBox, self input asBox
-		            connectTo: intermediateBox.
+	delayInSamples := self delayLength asBox * PhSampleRate new.
+	finalBox := self maxDelayLength asBox , delayInSamples asBox
+	            , self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/SinArcTan.class.st
+++ b/Phausto/SinArcTan.class.st
@@ -21,7 +21,7 @@ SinArcTan >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/SinArcTan2.class.st
+++ b/Phausto/SinArcTan2.class.st
@@ -21,7 +21,7 @@ SinArcTan2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input  asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/SineOsc.class.st
+++ b/Phausto/SineOsc.class.st
@@ -16,10 +16,10 @@ Class {
 { #category : 'initialization' }
 SineOsc >> asBox [
 
-	| intermediateBox finalBox  |
+	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self freq connectTo: intermediateBox.
-	^ finalBox * self uLevel
+	finalBox := self freq asBox connectTo: intermediateBox.
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'initialization' }

--- a/Phausto/SmoothDelay.class.st
+++ b/Phausto/SmoothDelay.class.st
@@ -16,13 +16,13 @@ Class {
 { #category : 'converting' }
 SmoothDelay >> asBox [
 
-	| intermediateBox finalBox  delayInSamples interpInSamples sampleRate |
+	| intermediateBox finalBox delayInSamples interpInSamples sampleRate |
 	sampleRate := PhSampleRate new.
-	delayInSamples := self delayLength * sampleRate .
-	interpInSamples := interpolationTime  * sampleRate .
+	delayInSamples := self delayLength asBox * sampleRate.
+	interpInSamples := interpolationTime * sampleRate.
 	intermediateBox := super asBox.
-	finalBox := self maxDelayLength asBox 
-	            , self interpolationTime asBox , delayInSamples asBox , self input asBox connectTo:
+	finalBox := self maxDelayLength asBox , self interpolationTime asBox
+	            , delayInSamples asBox , self input asBox connectTo:
 		            intermediateBox.
 	^ finalBox
 ]

--- a/Phausto/SoftClipQuadratic2.class.st
+++ b/Phausto/SoftClipQuadratic2.class.st
@@ -21,7 +21,7 @@ SoftClipQuadratic2 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Spatials.class.st
+++ b/Phausto/Spatials.class.st
@@ -16,7 +16,7 @@ Class {
 { #category : 'accessing' }
 Spatials >> input [
 
-	^ input ifNil:  [ input := Wire new ]
+	^ input 
 ]
 
 { #category : 'accessing' }
@@ -28,13 +28,7 @@ Spatials >> input: aPhBox [
 { #category : 'accessing' }
 Spatials >> pan [
 
-	^ pan ifNil: [
-		  PhHSlider new
-			  label: self label , 'Pan'
-			  init: 0.5
-			  min: 0
-			  max: 1
-			  step: 0.001 ]
+	^ pan 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/Spulse.class.st
+++ b/Phausto/Spulse.class.st
@@ -13,9 +13,9 @@ Class {
 		'n',
 		'input'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/SquareOsc.class.st
+++ b/Phausto/SquareOsc.class.st
@@ -19,10 +19,9 @@ Class {
 SquareOsc >> asBox [
 
 	| intermediateBox finalBox |
-
 	intermediateBox := super asBox.
-	finalBox := self freq connectTo: intermediateBox.
-	^ finalBox * self uLevel
+	finalBox := self freq asBox connectTo: intermediateBox.
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'as yet unclassified' }

--- a/Phausto/Sweep.class.st
+++ b/Phausto/Sweep.class.st
@@ -9,9 +9,9 @@ Class {
 		'period',
 		'run'
 	],
-	#category : 'Phausto-Basics',
+	#category : 'Phausto-Basics - Counters/TimeTools',
 	#package : 'Phausto',
-	#tag : 'Basics'
+	#tag : 'Basics - Counters/TimeTools'
 }
 
 { #category : 'converting' }

--- a/Phausto/Tanh1.class.st
+++ b/Phausto/Tanh1.class.st
@@ -21,7 +21,7 @@ Tanh1 >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self input connectTo: intermediateBox.
+	finalBox := self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/ToolkitTest.class.st
+++ b/Phausto/ToolkitTest.class.st
@@ -29,7 +29,7 @@ ToolkitTest >> testPhCaptureAsDsp [
 { #category : 'tests' }
 ToolkitTest >> testPhCounterAsDsp [
 
-	self assert: PhCounter new asDsp isNull equals: false
+	self assert: PhTkCounter new asDsp isNull equals: false
 ]
 
 { #category : 'tests' }

--- a/Phausto/TriOsc.class.st
+++ b/Phausto/TriOsc.class.st
@@ -13,10 +13,9 @@ Class {
 TriOsc >> asBox [
 
 	| intermediateBox finalBox |
-
 	intermediateBox := super asBox.
 	finalBox := self freq asBox connectTo: intermediateBox.
-	^ finalBox * self uLevel
+	^ finalBox * self uLevel asBox
 ]
 
 { #category : 'initialization' }

--- a/Phausto/UnitGenerator.class.st
+++ b/Phausto/UnitGenerator.class.st
@@ -181,9 +181,8 @@ emptyBox := PhBox new.
 { #category : 'converting' }
 UnitGenerator >> asDsp [
 	" creates a DSP from the Box with the default name MyApp"
-	
-	^ self asDspWithName: 'MyApp'
 
+	^ self asDspWithName: 'MyApp' source: self
 ]
 
 { #category : 'converting' }
@@ -206,12 +205,20 @@ UnitGenerator >> asDspMIDIWithName: aString [
 UnitGenerator >> asDspWithName: aString [
 	" creates a DSP from the Box"
 
-	|  interBox |
-	
-		
-					interBox := self asBox.
-					interBox traceCr.
-					^ interBox asDspWithName: aString.
+	| interBox |
+	interBox := self asBox.
+	interBox traceCr.
+	^ interBox asDspWithName: aString source: self
+]
+
+{ #category : 'converting' }
+UnitGenerator >> asDspWithName: aString source: self [
+	" creates a DSP from the Box"
+
+	| interBox |
+	interBox := self asBox.
+	interBox traceCr.
+	^ interBox asDspWithName: aString source: self
 ]
 
 { #category : 'converting' }

--- a/Phausto/UnitGenerator.class.st
+++ b/Phausto/UnitGenerator.class.st
@@ -217,7 +217,7 @@ UnitGenerator >> asDspWithName: aString [
 { #category : 'converting' }
 UnitGenerator >> asParam: aString forUGen: aUGen [
 
-aUGen instVarNamed: aString put: self asBox
+	aUGen instVarNamed: aString put: self 
 ]
 
 { #category : 'accessing' }

--- a/Phausto/ViolinModel.class.st
+++ b/Phausto/ViolinModel.class.st
@@ -19,11 +19,10 @@ Class {
 ViolinModel >> asBox [
 
 	| intermediateBox finalBox |
-
 	intermediateBox := super asBox.
 
-	finalBox := 
-	stringLength , bowVelocity , bowPressure , bowPosition connectTo: intermediateBox.
+	finalBox := self stringLength asBox , self bowVelocity asBox  , self bowPressure asBox , self  bowPosition asBox
+		            connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/Wah.class.st
+++ b/Phausto/Wah.class.st
@@ -24,7 +24,7 @@ Wah >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox :=  self fr , self input  connectTo: intermediateBox.
+	finalBox := self fr asBox, self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/Wavefold.class.st
+++ b/Phausto/Wavefold.class.st
@@ -23,7 +23,7 @@ Wavefold >> asBox [
 
 	| intermediateBox finalBox |
 	intermediateBox := super asBox.
-	finalBox := self width , self input connectTo: intermediateBox.
+	finalBox := self width asBox , self input asBox connectTo: intermediateBox.
 	^ finalBox
 ]
 

--- a/Phausto/ZitaRevStereo.class.st
+++ b/Phausto/ZitaRevStereo.class.st
@@ -28,10 +28,11 @@ Class {
 { #category : 'converting' }
 ZitaRevStereo >> asBox [
 
-	| intermediateBox  finalBox |
-	
-	intermediateBox := super asBox .
-	finalBox := self rdel, self f1 asBox, self f2 asBox , self t60dc asBox , self t60m asBox , self fsMax asBox , self inputL, self inputR connectTo: intermediateBox.
+	| intermediateBox finalBox |
+	intermediateBox := super asBox.
+	finalBox := self rdel , self f1 asBox , self f2 asBox
+	            , self t60dc asBox , self t60m asBox , self fsMax asBox
+	            , self inputL asBox , self inputR asBox connectTo: intermediateBox.
 
 	^ finalBox
 ]

--- a/Phausto/ZitaRevStereo.class.st
+++ b/Phausto/ZitaRevStereo.class.st
@@ -71,11 +71,11 @@ ZitaRevStereo >> fsMax [
 ]
 
 { #category : 'initialization' }
-ZitaRevStereo >> initialize [ 
+ZitaRevStereo >> initialize [
 
-super initialize .
-processExpression := 'process = re.zita_rev1_stereo;'.
-fsmax := 44100 asBox.
+	super initialize.
+	processExpression := 'process = re.zita_rev1_stereo;'.
+	fsmax := 44100 
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
all Unit Generators were cleaned in order to leave every transformation into PhBox to the last stage of DSP creation.
this should allow to store a 'source' of the dsp inside the dsp instance and also avoid the necessity to transform all UnitGenerators into Null Objects once the libContext is destroyed